### PR TITLE
Add `inverse_of` to the `auditable` and `audits` associations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Audited ChangeLog
 -------------------------------------------------------------------------------
+* 2017-10-09 - Include `inverse_of` on auditable associations [justinweiss]
 * 2017-07-27 - Don't exclude attributes when auditing destroys [k1w1]
 * 2012-04-10 - Add Audit scopes for creates, updates and destroys [chriswfx]
 * 2011-10-25 - Made ignored_attributes configurable [senny]

--- a/lib/audited/active_record/version.rb
+++ b/lib/audited/active_record/version.rb
@@ -1,5 +1,5 @@
 module Audited
   module ActiveRecord
-    VERSION = "4.2.1"
+    VERSION = "4.2.3"
   end
 end

--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -7,7 +7,7 @@ module Audited
 
     module ClassMethods
       def setup_audit
-        belongs_to :auditable,  :polymorphic => true
+        belongs_to :auditable,  :polymorphic => true, :inverse_of => :audits
         belongs_to :user,       :polymorphic => true
         belongs_to :associated, :polymorphic => true
 

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -60,7 +60,7 @@ module Audited
 
         attr_accessor :audit_comment
 
-        has_many :audits, :as => :auditable, :class_name => Audited.audit_class.name
+        has_many :audits, :as => :auditable, :class_name => Audited.audit_class.name, :inverse_of => :auditable
         Audited.audit_class.audited_class_names << self.to_s
 
         after_create  :audit_create if !options[:on] || (options[:on] && options[:on].include?(:create))

--- a/lib/audited/mongo_mapper/version.rb
+++ b/lib/audited/mongo_mapper/version.rb
@@ -1,5 +1,5 @@
 module Audited
   module MongoMapper
-    VERSION = "4.2.0"
+    VERSION = "4.2.3"
   end
 end

--- a/lib/audited/version.rb
+++ b/lib/audited/version.rb
@@ -1,3 +1,3 @@
 module Audited
-  VERSION = "4.2.2"
+  VERSION = "4.2.3"
 end


### PR DESCRIPTION
If you're navigating from a newly created audit back to its auditable,
you'll do an unneeded SQL query. With `inverse_of`, you don't have to.