### PR TITLE
PF-971-8-5-2-change-apis

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -176,10 +176,19 @@ module Audited
 
       private
 
-      def audited_changes
-        changed_attributes.except(*non_audited_columns).inject({}) do |changes,(attr, old_value)|
-          changes[attr] = [old_value, self[attr]]
-          changes
+      if Rails.version < 5.1
+        def audited_changes
+          changed_attributes.except(*non_audited_columns).inject({}) do |changes, (attr, old_value)|
+            changes[attr] = [old_value, self[attr]]
+            changes
+          end
+        end
+      else
+        def audited_changes
+          saved_changes.transform_values(&:first).except(*non_audited_columns).inject({}) do |changes, (attr, old_value)|
+            changes[attr] = [old_value, self[attr]]
+            changes
+          end
         end
       end
 

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -176,7 +176,7 @@ module Audited
 
       private
 
-      if Rails.version < 5.1
+      if Rails.version < "5.1"
         def audited_changes
           changed_attributes.except(*non_audited_columns).inject({}) do |changes, (attr, old_value)|
             changes[attr] = [old_value, self[attr]]


### PR DESCRIPTION
Dearest Reviewer,

Rails 5.1 and 5.2 change the changes api in a breaking way. This appears
to be the only call that is impacted.

Updated per the DEPRECATION WARNING!
DEPRECATION WARNING: The behavior of changed_attributes inside of after
callbacks will be changing in the next version of Rails. The new return
value will reflect the behavior of calling the method after save returned
(e.g. the opposite of what it returns now). To maintain the current behavior,
use saved_changes.transform_values(&:first) instead.

Becker